### PR TITLE
Make sure that all exception classes extend GoogleMapsJuice::ResponseError

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ This is especially useful in some "hybrid" scenario, where an API key is shared 
 
 ## Error Handling
 
-If Google servers respond with a non-successful HTTP status code, i.e. `4xx` or `5xx`, a `GoogleMapsJuice::Error` is raised with a message of the form `'HTTP 503 - Error details as returned by the server'`.
+If Google servers respond with a non-successful HTTP status code, i.e. `4xx` or `5xx`, a `GoogleMapsJuice::ResponseError` is raised with a message of the form `'HTTP 503 - Error details as returned by the server'`.
 
 API errors are also handled, based on the `status` attribute of Google's JSON response, and the optional `error_message` attribute.
 
 * `GoogleMapsJuice::ZeroResults` is raised when `status` is `'ZERO_RESULTS'`
 * `GoogleMapsJuice::ApiLimitError` is raised when `status` is `'OVER_DAILY_LIMIT'` or `'OVER_QUERY_LIMIT'`
-* `GoogleMapsJuice::Error` is raised when `status` is not `OK` with a message of the form `API <status> - <error_message>`
+* `GoogleMapsJuice::ResponseError` is raised when `status` is not `OK` with a message of the form `API <status> - <error_message>`
 
 
 ## Geocoding

--- a/lib/google_maps_juice.rb
+++ b/lib/google_maps_juice.rb
@@ -16,7 +16,7 @@ module GoogleMapsJuice
   autoload :Timezone, 'google_maps_juice/timezone'
   autoload :Directions, 'google_maps_juice/directions'
 
-  class Error < Exception; end
-  class ApiLimitError < Exception; end
-  class ZeroResults < Exception; end
+  class ResponseError < RuntimeError; end
+  class ApiLimitError < ResponseError; end
+  class ZeroResults < ResponseError; end
 end

--- a/lib/google_maps_juice/client.rb
+++ b/lib/google_maps_juice/client.rb
@@ -27,7 +27,7 @@ module GoogleMapsJuice
       else
         msg = "HTTP #{response.status}"
         msg += " - #{response.body}" if response.body.present?
-        raise GoogleMapsJuice::Error, msg
+        raise GoogleMapsJuice::ResponseError, msg
       end
     end
 

--- a/lib/google_maps_juice/endpoint.rb
+++ b/lib/google_maps_juice/endpoint.rb
@@ -14,7 +14,7 @@ module GoogleMapsJuice
       elsif response.limit_error?
         raise GoogleMapsJuice::ApiLimitError, build_error_message(response)
       elsif response.error?
-        raise GoogleMapsJuice::Error, "API #{build_error_message(response)}"
+        raise GoogleMapsJuice::ResponseError, "API #{build_error_message(response)}"
       else
         response
       end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe GoogleMapsJuice::Client, webmock: true do
       context 'when HTTP response status is not successful' do
         before { stub_request(:get, url_pattern).to_return(body: "Uh-oh, I crashed!", status: 503) }
 
-        it 'raises GoogleMapsJuice::Error' do
-          expect { subject }.to raise_error(GoogleMapsJuice::Error,
+        it 'raises GoogleMapsJuice::ResponseError' do
+          expect { subject }.to raise_error(GoogleMapsJuice::ResponseError,
             'HTTP 503 - Uh-oh, I crashed!'
           )
         end

--- a/spec/unit/endpoint_spec.rb
+++ b/spec/unit/endpoint_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe GoogleMapsJuice::Endpoint, webmock: true do
     context 'when response contains limit error' do
       let(:response) { response_fixture('limit-error') }
 
-      it 'raises GoogleMapsJuice::Error' do
+      it 'raises GoogleMapsJuice::ResponseError' do
         expect { subject }.to raise_error(GoogleMapsJuice::ApiLimitError,
           'OVER_QUERY_LIMIT - You have exceeded your daily request quota for this API.')
       end
@@ -51,8 +51,8 @@ RSpec.describe GoogleMapsJuice::Endpoint, webmock: true do
     context 'when response contains error' do
       let(:response) { response_fixture('error') }
 
-      it 'raises GoogleMapsJuice::Error' do
-        expect { subject }.to raise_error(GoogleMapsJuice::Error,
+      it 'raises GoogleMapsJuice::ResponseError' do
+        expect { subject }.to raise_error(GoogleMapsJuice::ResponseError,
           'API UNKNOWN_ERROR - A server error occurred, please retry later')
       end
     end


### PR DESCRIPTION
Renamed `GoogleMapsJuice::Error` to `GoogleMapsJuice::ResponseError` which inherits `RuntimeError`. `GoogleMapsJuice::ApiLimitError` and `GoogleMapsJuice::ZeroResults` inherit `GoogleMapsJuice::ResponseError`.
Updated  `README` section about Error Handling. 