### PR TITLE
Remove annoying warning in the directions specs

### DIFF
--- a/spec/integration/directions_spec.rb
+++ b/spec/integration/directions_spec.rb
@@ -2,11 +2,6 @@
 
 require 'spec_helper'
 
-ROME = '12.496365,41.902783'
-COLOSSEUM = '41.890209,12.492231'
-SAINTPETER = '41.902270,12.457540'
-SIDNEY = '-33.867487,151.206990'
-
 RSpec.describe GoogleMapsJuice::Directions do
   describe '.find' do
     subject { described_class.find(params) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,12 @@ module WebmockEnabler
   end
 end
 
+## Directions Helpers
+ROME = '12.496365,41.902783'
+COLOSSEUM = '41.890209,12.492231'
+SAINTPETER = '41.902270,12.457540'
+SIDNEY = '-33.867487,151.206990'
+
 RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/unit/directions_spec.rb
+++ b/spec/unit/directions_spec.rb
@@ -2,11 +2,6 @@
 
 require 'spec_helper'
 
-ROME = '12.496365,41.902783'
-COLOSSEUM = '41.890209,12.492231'
-SAINTPETER = '41.902270,12.457540'
-SIDNEY = '-33.867487,151.206990'
-
 # TODO: cover the remaining contexts
 RSpec.describe GoogleMapsJuice::Directions do
   let(:client) { GoogleMapsJuice::Client.new }


### PR DESCRIPTION
Moved the constants of the directions coordinates in `spec_helper` to avoid duplication warnings