### PR TITLE
fix(ci): generate LCOV coverage report for Codecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development, :test do
   gem 'dotenv', '~> 3.0'
   gem 'vcr', '~> 6.0'
   gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -88,6 +89,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   simplecov
+  simplecov-lcov
   vcr (~> 6.0)
   webmock (~> 3.0)
 
@@ -122,6 +124,7 @@ CHECKSUMS
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov-lcov (0.9.0) sha256=7a77a31e200a595ed4b0249493056efd0c920601f53d2ef135ca34ee796346cd
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Drink Google Maps Services with ease!** :tropical_drink: :earth_americas:
 
-[![Build Status](https://travis-ci.org/algonauti/google_maps_juice.svg?branch=master)](https://travis-ci.org/algonauti/google_maps_juice)
-[![Coverage Status](https://coveralls.io/repos/github/algonauti/google_maps_juice/badge.svg?branch=master)](https://coveralls.io/github/algonauti/google_maps_juice?branch=master)
+[![CI](https://github.com/algonauti/google_maps_juice/actions/workflows/ci.yml/badge.svg)](https://github.com/algonauti/google_maps_juice/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/algonauti/google_maps_juice/branch/main/graph/badge.svg)](https://codecov.io/gh/algonauti/google_maps_juice)
 
 This gem aims at progressively covering a fair amount of those widely-used services that are part of the Google Maps Platform, such as: [Geocoding](https://developers.google.com/maps/documentation/geocoding/intro), [Time Zone](https://developers.google.com/maps/documentation/timezone/intro), [Directions](https://developers.google.com/maps/documentation/directions/intro), etc. with some key ideas:
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
-require 'simplecov'
-SimpleCov.start if ENV['CI']
+if ENV['CI']
+  require 'simplecov'
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config.report_with_adapter_at_branch_level = false
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+  SimpleCov.start
+end
 
 require "bundler/setup"
 require "google_maps_juice"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 if ENV['CI']
   require 'simplecov'
   require 'simplecov-lcov'
-  SimpleCov::Formatter::LcovFormatter.config.report_with_adapter_at_branch_level = false
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
   SimpleCov.start
 end


### PR DESCRIPTION
## Problem

The Codecov uploader was reporting _"Found 0 coverage files to report"_ because it doesn't recognise SimpleCov's default output formats (`.resultset.json` / HTML).

## Fix

- Add `simplecov-lcov` gem, which produces a standard LCOV file (`coverage/lcov/*.lcov`) that Codecov auto-detects
- Reconfigure `spec_helper.rb` to use `LcovFormatter` when running in CI (behaviour outside CI is unchanged)

No changes to the workflow file are needed — `codecov/codecov-action@v5` scans for LCOV files automatically.